### PR TITLE
Add onlyCountries attribute.

### DIFF
--- a/projects/ngx-intl-tel-input/package.json
+++ b/projects/ngx-intl-tel-input/package.json
@@ -31,5 +31,8 @@
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/webcat12345/ngx-intl-tel-input/issues"
+  },
+  "devDependencies": {
+    "@types/google-libphonenumber": "^7.4.17"
   }
 }

--- a/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.validator.ts
+++ b/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.validator.ts
@@ -4,7 +4,7 @@ import * as lpn from 'google-libphonenumber';
 export const phoneNumberValidator = (control: FormControl) => {
 	const error = { validatePhoneNumber: { valid: false } };
 
-	let number: number;
+	let number: lpn.PhoneNumber;
 	try {
 		number = lpn.PhoneNumberUtil.getInstance().parse(control.value.number, control.value.countryCode);
 	} catch (e) {

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -3,11 +3,13 @@
   <h3>Test International Telephone Input Form</h3>
   <br>
   <form #f="ngForm" [formGroup]="phoneForm">
-    <ngx-intl-tel-input 
-    [cssClass]="'custom'" 
-    [preferredCountries]="['us', 'gb']" 
-    [enablePlaceholder]="true" 
-    name="phone" 
+    <ngx-intl-tel-input
+    [cssClass]="'custom'"
+    [preferredCountries]="['us', 'gb']"
+    [onlyCountries]="['us', 'gb', 'es']"
+    [enableAutoCountrySelect]="true"
+    [enablePlaceholder]="true"
+    name="phone"
     formControlName="phone"></ngx-intl-tel-input>
   </form>
   <br>


### PR DESCRIPTION

Fixes #37.
Add onlyCountries attribute to limit the countries (e.g ['us','gb','es'])
Add @types/google-libphonenumber to have intellisense in the library.
Add enableAutoCountrySelect to auto change the country based on the extension ( e.g change to Spain if number starts with +34)
