### PR TITLE
 Show divider only when there are preferredCountries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 /out-tsc
 
 # dependencies
-/node_modules
+node_modules
 
 # profiling files
 chrome-profiler-events.json

--- a/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.html
+++ b/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.html
@@ -12,7 +12,7 @@
         <span class="country-name">{{country.name}}</span>
         <span class="dial-code">+{{country.dialCode}}</span>
       </li>
-      <li class="divider"></li>
+      <li class="divider" *ngIf="preferredCountriesInDropDown.length"></li>
       <li class="country" *ngFor="let country of allCountries" (click)="onCountrySelect(country, focusable)">
         <div class="flag-box">
           <div class="iti-flag" [ngClass]="country.flagClass"></div>

--- a/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.html
+++ b/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.html
@@ -12,7 +12,7 @@
         <span class="country-name">{{country.name}}</span>
         <span class="dial-code">+{{country.dialCode}}</span>
       </li>
-      <li class="divider" *ngIf="preferredCountriesInDropDown.length"></li>
+      <li class="divider" *ngIf="preferredCountriesInDropDown?.length"></li>
       <li class="country" *ngFor="let country of allCountries" (click)="onCountrySelect(country, focusable)">
         <div class="flag-box">
           <div class="iti-flag" [ngClass]="country.flagClass"></div>


### PR DESCRIPTION
When there are no preferred countries, the dropdown shows a divider:
![image](https://user-images.githubusercontent.com/6862893/52216693-1fc9c380-2897-11e9-9400-cc73a44f3e09.png)


I think we can only show the divider, because it looks weird otherwise.

With this pr, when there are no preferred countries, it looks like this:
![image](https://user-images.githubusercontent.com/6862893/52216613-f446d900-2896-11e9-8390-b5d7139c1e32.png)
