### PR TITLE
Bug: On form reset, the input text field is not cleared while the form control value is set to null.

### DIFF
--- a/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.html
+++ b/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.html
@@ -22,7 +22,7 @@
       </li>
     </ul>
   </div>
-  <input type="tel" id="phone" autocomplete="off"
+  <input type="tel" id="ngx-intl-tel-input-phone" autocomplete="off"
         [ngClass]="cssClass"
         (blur)="onTouched()"
         (keypress)="onInputKeyPress($event)"

--- a/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.ts
+++ b/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.ts
@@ -73,7 +73,10 @@ export class NgxIntlTelInputComponent implements OnInit {
 
 	public onPhoneNumberChange(): void {
 		this.value = this.phoneNumber;
-
+    if(this.phoneNumber===undefined){
+    let phone = <HTMLInputElement>document.getElementById('ngx-intl-tel-input-phone');
+    phone.value=null;
+    }
 		let number: lpn.PhoneNumber;
 		try {
 			number = this.phoneUtil.parse(this.phoneNumber, this.selectedCountry.iso2.toUpperCase());

--- a/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.ts
+++ b/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.ts
@@ -73,7 +73,7 @@ export class NgxIntlTelInputComponent implements OnInit {
 
 	public onPhoneNumberChange(): void {
 		this.value = this.phoneNumber;
-    if(this.phoneNumber===undefined){
+    if(this.phoneNumber === undefined || this.phoneNumber === null || this.phoneNumber === ''){
     let phone = <HTMLInputElement>document.getElementById('ngx-intl-tel-input-phone');
     phone.value=null;
     }


### PR DESCRIPTION
The fix should check for a change in the phone number value and clear the input field if phone number value has been set to null, undefined or ''  programmatically.