### PR TITLE
Fixing #248 duplicate countries in dropdown

### DIFF
--- a/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.ts
+++ b/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.ts
@@ -289,6 +289,9 @@ export class NgxIntlTelInputComponent implements OnInit, OnChanges {
 	}
 
 	protected fetchCountryData(): void {
+		/* Clearing the list to avoid duplicates (https://github.com/webcat12345/ngx-intl-tel-input/issues/248) */
+		this.allCountries = [];
+
 		this.countryCodeData.allCountries.forEach(c => {
 			const country: Country = {
 				name: c[0].toString(),


### PR DESCRIPTION
- Reset allCountries field to empty list in fetchCountryData()

Fixing https://github.com/webcat12345/ngx-intl-tel-input/issues/248