### PR TITLE
fixed invalid css pseudo class when tel input is invalid

### DIFF
--- a/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.validator.ts
+++ b/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.validator.ts
@@ -3,18 +3,25 @@ import * as lpn from 'google-libphonenumber';
 
 export const phoneNumberValidator = (control: FormControl) => {
 	const id = control.value && control.value.id ? control.value.id : 'phone';
-	const el = document.getElementById(id) ? document.getElementById(id) : undefined;
+	const el = document.getElementById(id) ? (<HTMLInputElement>document.getElementById(id)) : undefined;
 	if (el) {
 		const isCheckValidation = el.getAttribute('validation');
 		if (isCheckValidation === 'true') {
 			const isRequired = control.errors && control.errors.required === true;
-			const error = { validatePhoneNumber: { valid: false } };
+      const error = { validatePhoneNumber: { valid: false } };
+
+      el.setCustomValidity("Invalid field.");
+
 			let number: lpn.PhoneNumber;
 
 			try {
 				number = lpn.PhoneNumberUtil.getInstance().parse(control.value.number, control.value.countryCode);
 			} catch (e) {
-				if (isRequired === true) { return error; }
+        if (isRequired === true) {
+          return error;
+        } else {
+          el.setCustomValidity('');
+        }
 			}
 
 			if (control.value) {
@@ -23,10 +30,14 @@ export const phoneNumberValidator = (control: FormControl) => {
 				} else {
 					if (!lpn.PhoneNumberUtil.getInstance().isValidNumberForRegion(number, control.value.countryCode)) {
 						return error;
-					}
+					} else {
+            el.setCustomValidity('');
+          }
 				}
 			}
 		} else if (isCheckValidation === 'false') {
+      el.setCustomValidity('');
+
 			control.clearValidators();
 		}
 	}


### PR DESCRIPTION
added a small fix (workaround) for the tel input field css validation pseudo classes :valid and :invalid to match the validation state of the provided control.
this will be useful in cases like using bootstrap 4 forms validation classes
https://getbootstrap.com/docs/4.4/components/forms/?#validation

:invalid pseudo class example
![Screenshot from 2020-04-10 01-15-55](https://user-images.githubusercontent.com/29521303/78948438-9cbe8180-7ac8-11ea-86f3-d5f5747df342.png)

:valid pseudo class example
![Screenshot from 2020-04-10 01-15-30](https://user-images.githubusercontent.com/29521303/78948486-c8da0280-7ac8-11ea-8c33-a68f7824cc95.png)
