### PR TITLE
fixed country dropdown to be unclickable when control is disabled

### DIFF
--- a/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.html
+++ b/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.html
@@ -1,5 +1,5 @@
 <div class="intl-tel-input allow-dropdown" [ngClass]="separateDialCodeClass">
-  <div class="flag-container" dropdown [ngClass]="{'disabled': disabled}">
+  <div class="flag-container" dropdown [ngClass]="{'disabled': disabled}" [isDisabled]="disabled">
     <div class="selected-flag dropdown-toggle" dropdownToggle>
       <div class="iti-flag" [ngClass]="selectedCountry?.flagClass"
         [tooltip]="selectedCountry ? selectedCountry[tooltipField] : ''"></div>


### PR DESCRIPTION
Fixed country dropdown to be unclickable when control is disabled.
This pr should solve this issue https://github.com/webcat12345/ngx-intl-tel-input/issues/205 