### PR TITLE
added E164 Format also provided by the javascript google/libphonenumber

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,13 @@ Or this [Stackblitz Demo](https://stackblitz.com/edit/ngx-intl-tel-input-demo).
 | separateDialCode | ```boolean``` | ```false``` | Visually separate dialcode into the drop down element. |
 | countryChange | ```<Country>``` | ```None``` | Emits country value when the user selects a country from the dropdown. |
 
+## Supported Formats
+
+Following formats are supported
+- NATIONAL // Produces "044 668 18 00"
+- INTERNATIONAL // Produces "+41 44 668 18 00"
+- E164 // Produces "+41446681800"
+
 ## Library Contributions
 
 - Fork repo.

--- a/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.ts
+++ b/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.ts
@@ -244,6 +244,7 @@ export class NgxIntlTelInputComponent implements OnInit, OnChanges {
 				number: this.value,
 				internationalNumber: intlNo,
 				nationalNumber: number ? this.phoneUtil.format(number, lpn.PhoneNumberFormat.NATIONAL) : '',
+				e164Number: number ? this.phoneUtil.format(number, lpn.PhoneNumberFormat.E164): '',
 				countryCode: countryCode.toUpperCase(),
 				dialCode: '+' + this.selectedCountry.dialCode,
 				id: this.id
@@ -276,6 +277,7 @@ export class NgxIntlTelInputComponent implements OnInit, OnChanges {
 				number: this.value,
 				internationalNumber: intlNo,
 				nationalNumber: number ? this.phoneUtil.format(number, lpn.PhoneNumberFormat.NATIONAL) : '',
+				e164Number: number ? this.phoneUtil.format(number, lpn.PhoneNumberFormat.E164): '',
 				countryCode: this.selectedCountry.iso2.toUpperCase(),
 				dialCode: '+' + this.selectedCountry.dialCode,
 				id: this.id


### PR DESCRIPTION
Added the E164 format to the library. Currently there were only 'National' and 'International' format. This format is widely used while persisting the phone number which may later be used with user authentication and SMS and Call notifications without 'Replacing' empty spaces manually which are otherwise present in 'International' format.

Also updated the README to clearly mention the supported formats.