### PR TITLE
Merge pull request #245 from mapiacompany/fix/ngx-bootstrap

### DIFF
--- a/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.module.ts
+++ b/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.module.ts
@@ -1,9 +1,10 @@
 import { NgModule, ModuleWithProviders } from '@angular/core';
 import { NgxIntlTelInputComponent } from './ngx-intl-tel-input.component';
 import { CommonModule } from '@angular/common';
-import { BsDropdownModule, TooltipModule } from 'ngx-bootstrap';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { NgxIntlTelInputService } from './ngx-intl-tel-input.service';
+import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
+import { TooltipModule } from 'ngx-bootstrap/tooltip';
 
 @NgModule({
 	declarations: [NgxIntlTelInputComponent],

--- a/tslint.json
+++ b/tslint.json
@@ -13,7 +13,10 @@
     "curly": true,
     "eofline": true,
     "forin": true,
-    "import-blacklist": [true],
+    "import-blacklist": [
+      true,
+      "ngx-bootstrap"
+    ],
     "import-spacing": true,
     "indent": [
       true,


### PR DESCRIPTION
Angular 7 support
fix(ngx-intl-tel-input): do not use 'ngx-bootstrap' import-path 