### PR TITLE
Handle ChangeData object as input to formControl

### DIFF
--- a/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.ts
+++ b/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.ts
@@ -224,17 +224,25 @@ export class NgxIntlTelInputComponent implements OnInit, OnChanges {
 	}
 
 	public onPhoneNumberChange(): void {
-		this.value = this.phoneNumber;
 
+		let countryCode: string | undefined;
+		// Handle the case where the user sets the value programatically based on a persisted ChangeData obj.
+		if (this.phoneNumber && typeof this.phoneNumber === 'object') {
+			const numberObj: ChangeData = this.phoneNumber;
+			this.phoneNumber = numberObj.number;
+			countryCode = numberObj.countryCode;
+		}
+
+		this.value = this.phoneNumber;
+		countryCode = countryCode || this.selectedCountry.iso2.toUpperCase();
 		let number: lpn.PhoneNumber;
 		try {
 			number = this.phoneUtil.parse(
 				this.phoneNumber,
-				this.selectedCountry.iso2.toUpperCase()
+				countryCode,
 			);
 		} catch (e) {}
 
-		let countryCode = this.selectedCountry.iso2;
 		// auto select country based on the extension (and areaCode if needed) (e.g select Canada if number starts with +1 416)
 		if (this.enableAutoCountrySelect) {
 			countryCode =


### PR DESCRIPTION
Fixes #299 which describes how the backing state for the component cannot be replenished (ex: from a store) using its `ChangeData` object value. 

This adds some logic to `onPhoneNumberChange` which checks if `typeof this.phoneNumber == 'object` and if so, grabs the number and country code from the object, and continues parsing normally. Wasn't 100% sure how to handle this but I'm open to your feedback!