### PR TITLE
Fix styles to be compatible with bootstrap & Update demo UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Or this:
 
 | Options                  | Type                     | Default                           | Description                                                                                                   |
 | ------------------------ | ------------------------ | --------------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| cssClass                 | `string`                 | `control-form`                    | Bootstrap input css class or your own custom one.                                                             |
+| cssClass                 | `string`                 | `form-control`                    | Bootstrap input css class or your own custom one.                                                             |
 | preferredCountries       | `<CountryISO>[]`         | `[]`                              | List of countries, which will appear at the top.                                                              |
 | onlyCountries            | `<CountryISO>[]`         | `[]`                              | List of manually selected countries, which will appear in the dropdown.                                       |
 | enableAutoCountrySelect  | `boolean`                | `true`                            | Toggle automatic country (flag) selection based on user input.                                                |

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@angular/platform-browser": "~11.2.1",
     "@angular/platform-browser-dynamic": "~11.2.1",
     "@angular/router": "~11.2.1",
-    "bootstrap": "^4.5.2",
+    "bootstrap": "^4.6.0",
     "core-js": "^3.6.5",
     "google-libphonenumber": "^3.2.3",
     "intl-tel-input": "^17.0.3",

--- a/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.css
+++ b/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.css
@@ -57,3 +57,8 @@ li.iti__country:hover {
 .iti.separate-dial-code.iti--allow-dropdown.iti-sdc-4 input {
 	padding-left: 98px;
 }
+
+.intl-tel-input {
+  width: 100%;
+  display: block;
+}

--- a/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.html
+++ b/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.html
@@ -17,6 +17,7 @@
 			<div class="search-container"
 				*ngIf="searchCountryFlag && searchCountryField">
 				<input id="country-search-box"
+					class="form-control"
 					[(ngModel)]="countrySearchText"
 					(keyup)="searchCountry()"
 					(click)="$event.stopPropagation()"

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,52 +1,53 @@
 <!--The content below is only a placeholder and can be replaced.-->
-<div style="margin: 50px">
-	<h1>Test International Telephone Input Form</h1>
-	<br>
-	<div class="wrapper">
-		<button (click)="changePreferredCountries()">Change Preferred Countries</button>
-	</div>
-	<div class="wrapper">
-		<input type="checkbox"
-			[(ngModel)]="separateDialCode">
-		<label>&nbsp;Separate Dial Code?</label>
-	</div>
-	<form #f="ngForm"
-		[formGroup]="phoneForm">
-		<div class="wrapper">
-			<ngx-intl-tel-input [cssClass]="'custom'"
-				[preferredCountries]="preferredCountries"
-				[enableAutoCountrySelect]="true"
-				[enablePlaceholder]="true"
-				[searchCountryFlag]="true"
-				[searchCountryField]="[SearchCountryField.Iso2, SearchCountryField.Name]"
-				[selectFirstCountry]="false"
-				[selectedCountryISO]="CountryISO.India"
-				[maxLength]="15"
-				[phoneValidation]="true"
-				[separateDialCode]="separateDialCode"
-				[numberFormat]="PhoneNumberFormat.National"
-				name="phone"
-				formControlName="phone">
-			</ngx-intl-tel-input>
+<div class="container mt-5">
+	<h3>Test International Telephone Input Form</h3>
+	<hr />
+
+	<div class="row">
+		<div class="col-md-8">
+			<form [formGroup]="phoneForm">
+				<div class="form-group">
+					<label for="phone">Phone number</label>
+					<ngx-intl-tel-input [cssClass]="'form-control'" [preferredCountries]="preferredCountries"
+						[enableAutoCountrySelect]="false" [enablePlaceholder]="true" [searchCountryFlag]="true"
+						[searchCountryField]="[searchField.Iso2, searchField.Name]" [selectFirstCountry]="false"
+						[selectedCountryISO]="countries.India" [maxLength]="15" [tooltipField]="tooltipLabel"
+						[phoneValidation]="true" [separateDialCode]="separateDialCode" name="phone" formControlName="phone">
+					</ngx-intl-tel-input>
+				</div>
+				<button class="btn btn-danger" (click)="phoneForm.reset()">Reset</button>
+			</form>
+
 		</div>
-		<div class="wrapper">
-			<button (click)="f.reset()">Reset</button>
+		<div class="col-md-4">
+			<div class="my-2">
+				<button class="btn btn-primary" (click)="changePreferredCountries()">Change Preferred Countries</button>
+				<div class="form-check">
+					<input name="separateDialCode" class="form-check-input" type="checkbox" [(ngModel)]="separateDialCode">
+					<label class="form-check-label" for="separateDialCode">Separate Dial Code?</label>
+				</div>
+			</div>
+
+			<div>
+				<b>Is input valid:</b>
+				<pre>{{ !f.phone?.invalid }}</pre>
+			</div>
+			<div>
+				<b>Is input touched:</b>
+				<pre>{{ f.phone?.touched }}</pre>
+			</div>
+			<div>
+				<b>Is form valid:</b>
+				<pre>{{ phoneForm.valid }}</pre>
+			</div>
+			<div>
+				<b>Form value:</b>
+				<pre>{{ phoneForm.value | json }}</pre>
+			</div>
+			<div>
+				<b>Form validation errors:</b>
+				<pre>{{ f.phone?.errors | json }}</pre>
+			</div>
 		</div>
-	</form>
-	<br>
-	<div><strong>Is input valid:</strong>
-		<pre>{{ !f.form.controls['phone'].invalid }}</pre>
-	</div>
-	<div><strong>Is input touched:</strong>
-		<pre>{{ f.form.controls['phone'].touched }}</pre>
-	</div>
-	<div><strong>Is form valid:</strong>
-		<pre>{{ f.form.valid }}</pre>
-	</div>
-	<div><strong>Form value:</strong>
-		<pre>{{ f.form.value | json }}</pre>
-	</div>
-	<div><strong>Form validation errors:</strong>
-		<pre>{{ f.form.controls['phone'].errors | json }}</pre>
 	</div>
 </div>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -8,23 +8,43 @@
 			<form [formGroup]="phoneForm">
 				<div class="form-group">
 					<label for="phone">Phone number</label>
-					<ngx-intl-tel-input [cssClass]="'form-control'" [preferredCountries]="preferredCountries"
-						[enableAutoCountrySelect]="false" [enablePlaceholder]="true" [searchCountryFlag]="true"
-						[searchCountryField]="[searchField.Iso2, searchField.Name]" [selectFirstCountry]="false"
-						[selectedCountryISO]="countries.India" [maxLength]="15" [tooltipField]="tooltipLabel"
-						[phoneValidation]="true" [separateDialCode]="separateDialCode" name="phone" formControlName="phone">
+					<ngx-intl-tel-input
+						[cssClass]="'form-control'"
+						[preferredCountries]="preferredCountries"
+						[enableAutoCountrySelect]="false"
+						[enablePlaceholder]="true"
+						[searchCountryFlag]="true"
+						[searchCountryField]="[searchField.Iso2, searchField.Name]"
+						[selectFirstCountry]="false"
+						[selectedCountryISO]="countries.India"
+						[maxLength]="15"
+						[phoneValidation]="true"
+						[separateDialCode]="separateDialCode"
+						name="phone"
+						formControlName="phone"
+					>
 					</ngx-intl-tel-input>
 				</div>
-				<button class="btn btn-danger" (click)="phoneForm.reset()">Reset</button>
+				<button class="btn btn-danger" (click)="phoneForm.reset()">
+					Reset
+				</button>
 			</form>
-
 		</div>
 		<div class="col-md-4">
 			<div class="my-2">
-				<button class="btn btn-primary" (click)="changePreferredCountries()">Change Preferred Countries</button>
+				<button class="btn btn-primary" (click)="changePreferredCountries()">
+					Change Preferred Countries
+				</button>
 				<div class="form-check">
-					<input name="separateDialCode" class="form-check-input" type="checkbox" [(ngModel)]="separateDialCode">
-					<label class="form-check-label" for="separateDialCode">Separate Dial Code?</label>
+					<input
+						name="separateDialCode"
+						class="form-check-input"
+						type="checkbox"
+						[(ngModel)]="separateDialCode"
+					/>
+					<label class="form-check-label" for="separateDialCode"
+						>Separate Dial Code?</label
+					>
 				</div>
 			</div>
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -13,7 +13,6 @@ import { PhoneNumberFormat } from 'projects/ngx-intl-tel-input/src/public_api';
 export class AppComponent {
 	public separateDialCode = true;
 	public searchField = SearchCountryField;
-	public tooltipLabel = TooltipLabel.Name;
 	public countries = CountryISO;
 
 	public preferredCountries: CountryISO[] = [

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -11,19 +11,25 @@ import { PhoneNumberFormat } from 'projects/ngx-intl-tel-input/src/public_api';
 	styleUrls: ['./app.component.css'],
 })
 export class AppComponent {
-	separateDialCode = false;
-	SearchCountryField = SearchCountryField;
-	CountryISO = CountryISO;
-	PhoneNumberFormat = PhoneNumberFormat;
-	preferredCountries: CountryISO[] = [
+	public separateDialCode = true;
+	public searchField = SearchCountryField;
+	public tooltipLabel = TooltipLabel.Name;
+	public countries = CountryISO;
+
+	public preferredCountries: CountryISO[] = [
 		CountryISO.UnitedStates,
 		CountryISO.UnitedKingdom,
 	];
-	phoneForm = new FormGroup({
+
+	public phoneForm = new FormGroup({
 		phone: new FormControl(undefined, [Validators.required]),
 	});
 
-	changePreferredCountries() {
+	public get f() {
+		return this.phoneForm.controls;
+	}
+
+	public changePreferredCountries() {
 		this.preferredCountries = [CountryISO.India, CountryISO.Canada];
 	}
 }


### PR DESCRIPTION
This PR makes the control respond to being given a form-control class through bootstrap properly. Previously the width was fixed, and the the control was inline meaning it did not respond like a traditional bootstrap component in a form or in a `form-group` div.

There was also an error in the readme, saying the default value for `cssClass` is "control-form" when it should be "form-control"

Also updated the demo app to use bootstrap styles on buttons, as well as repsonsive layout.

**Before:**
![image](https://user-images.githubusercontent.com/8946502/87499716-400dcc80-c69e-11ea-837b-7940c1f877f6.png)

**After:**
![after](https://user-images.githubusercontent.com/8946502/87499732-4603ad80-c69e-11ea-9561-faba89762164.png)

The traditional bootstrap way of using forms is

```
<form>
  <div class="form-group">
    <label for="phone">Phone number</label>
    <input type="text" class="form-control" name="phone" />
  </div>
</form>
```

Bootstrap form components are `width: 100%` and block level. 
Using the above html format on the default demo app and the input class changed to `form-control` provides the following incorrect format:

![image](https://user-images.githubusercontent.com/8946502/87499988-d7731f80-c69e-11ea-9845-5672fadfd0fa.png)
