### PR TITLE
when auto select country by country code, sort all countries by priority first.

### DIFF
--- a/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.ts
+++ b/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.ts
@@ -255,7 +255,9 @@ export class NgxIntlTelInputComponent implements OnInit, OnChanges {
 					? this.getCountryIsoCode(number.getCountryCode(), number)
 					: this.selectedCountry.iso2;
 			if (countryCode && countryCode !== this.selectedCountry.iso2) {
-				const newCountry = this.allCountries.find(
+				const newCountry = this.allCountries.sort((a, b) => {
+					return a.priority - b.priority;
+				}).find(
 					(c) => c.iso2 === countryCode
 				);
 				if (newCountry) {

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -15,7 +15,7 @@
 		<div class="mb-2">
 			<ngx-intl-tel-input [cssClass]="'custom'"
 				[preferredCountries]="preferredCountries"
-				[enableAutoCountrySelect]="false"
+				[enableAutoCountrySelect]="true"
 				[enablePlaceholder]="true"
 				[searchCountryFlag]="true"
 				[searchCountryField]="[SearchCountryField.Iso2, SearchCountryField.Name]"


### PR DESCRIPTION
I got an issue when I input a Russian number. The number starts with +7, but the country Kazakhstan was auto-selected since the country code is also +7 and there is no area code listed. I checked the country-code.ts and found there is a priority attribute that can be used. I think it's better to auto-select the country by priority.