### PR TITLE
Sorting should be done on a clone of countries 

### DIFF
--- a/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.ts
+++ b/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.ts
@@ -230,7 +230,7 @@ export class NgxIntlTelInputComponent implements OnInit, OnChanges {
 					: this.selectedCountry.iso2;
 			if (countryCode && countryCode !== this.selectedCountry.iso2) {
 				const newCountry = this.allCountries
-					.sort((a, b) => {
+					.slice().sort((a, b) => {
 						return a.priority - b.priority;
 					})
 					.find((c) => c.iso2 === countryCode);


### PR DESCRIPTION
Sorting in javascript happens in-place. We need to do it on a clone of original array to keep countries in correct order for display.