### PR TITLE
fix: Issue-317 set autocomplete attribute for search countries input 

### DIFF
--- a/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.html
+++ b/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.html
@@ -21,6 +21,7 @@
 					(keyup)="searchCountry()"
 					(click)="$event.stopPropagation()"
 					[placeholder]="searchCountryPlaceholder"
+					[autocomplete]="searchCountryAutocomplete"
 					autofocus>
 			</div>
 			<ul class="iti__country-list"

--- a/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.ts
+++ b/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.ts
@@ -56,6 +56,7 @@ export class NgxIntlTelInputComponent implements OnInit, OnChanges {
 	@Input() searchCountryFlag = false;
 	@Input() searchCountryField: SearchCountryField[] = [SearchCountryField.All];
 	@Input() searchCountryPlaceholder = 'Search Country';
+	@Input() searchCountryAutocomplete: string = 'on';
 	@Input() maxLength: number;
 	@Input() selectFirstCountry = true;
 	@Input() selectedCountryISO: CountryISO;

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -21,6 +21,7 @@
 				[searchCountryField]="[SearchCountryField.Iso2, SearchCountryField.Name]"
 				[selectFirstCountry]="false"
 				[selectedCountryISO]="CountryISO.India"
+				[searchCountryAutocomplete]="'off'"
 				[maxLength]="15"
 				[phoneValidation]="true"
 				[separateDialCode]="separateDialCode"


### PR DESCRIPTION
There is an  [open issue](https://github.com/webcat12345/ngx-intl-tel-input/issues/317) requesting this. This simple feature saves innecesary code for removing the default browser suggestions for the search countries input that overlaps the countries dropdown. 