### PR TITLE
fix: ignore `+` for dial code searching

### DIFF
--- a/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.css
+++ b/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.css
@@ -1,6 +1,9 @@
 li.iti__country:hover {
 	background-color: rgba(0, 0, 0, 0.05);
 }
+li.iti__country:focus {
+	background-color: rgba(0, 0, 0, 0.1);
+}
 .iti__selected-flag.dropdown-toggle:after {
 	content: none;
 }

--- a/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.html
+++ b/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.html
@@ -2,10 +2,17 @@
 	[ngClass]="separateDialCodeClass">
 	<div class="iti__flag-container"
 		dropdown
+    [autoClose]="true"
+    #countryListDropdown="bs-dropdown"
 		[ngClass]="{'disabled': disabled}"
 		[isDisabled]="disabled">
 		<div class="iti__selected-flag dropdown-toggle"
-			dropdownToggle>
+      #dropdownToggle
+      tabindex="0"
+      role="button"
+      (click)="openCountryList($event)"
+      (keyup.enter)="openCountryList($event)"
+    >
 			<div class="iti__flag"
 				[ngClass]="selectedCountry?.flagClass || ''"></div>
 			<div *ngIf="separateDialCode"
@@ -17,30 +24,38 @@
 			<div class="search-container"
 				*ngIf="searchCountryFlag && searchCountryField">
 				<input id="country-search-box"
+          tabindex="0"
 					[(ngModel)]="countrySearchText"
 					(keyup)="searchCountry()"
 					(click)="$event.stopPropagation()"
 					[placeholder]="searchCountryPlaceholder"
+          autocomplete="off"
 					autofocus>
 			</div>
 			<ul class="iti__country-list"
 				#countryList>
-				<li class="iti__country iti__preferred"
-					*ngFor="let country of preferredCountriesInDropDown"
-					(click)="onCountrySelect(country, focusable)"
-					[id]="country.htmlId+'-preferred'">
-					<div class="iti__flag-box">
-						<div class="iti__flag"
-							[ngClass]="country.flagClass"></div>
-					</div>
-					<span class="iti__country-name">{{country.name}}</span>
-					<span class="iti__dial-code">+{{country.dialCode}}</span>
-				</li>
+        <ng-container *ngIf="!countrySearchText">
+          <li class="iti__country iti__preferred"
+            *ngFor="let country; let index = index of preferredCountriesInDropDown"
+            (click)="onCountrySelect(country, focusable)"
+            (keyup.enter)="onCountrySelect(country, focusable)"
+            tabindex="0"
+            [id]="country.htmlId+'-preferred'">
+            <div class="iti__flag-box">
+              <div class="iti__flag"
+                [ngClass]="country.flagClass"></div>
+            </div>
+            <span class="iti__country-name">{{country.name}}</span>
+            <span class="iti__dial-code">+{{country.dialCode}}</span>
+          </li>
+        </ng-container>
 				<li class="iti__divider"
 					*ngIf="preferredCountriesInDropDown?.length"></li>
 				<li class="iti__country iti__standard"
-					*ngFor="let country of allCountries"
+					*ngFor="let country of countriesList"
+          tabindex="0"
 					(click)="onCountrySelect(country, focusable)"
+          (keyup.enter)="onCountrySelect(country, focusable)"
 					[id]="country.htmlId">
 					<div class="iti__flag-box">
 						<div class="iti__flag"
@@ -53,6 +68,7 @@
 		</div>
 	</div>
 	<input type="tel"
+    tabindex="0"
 		[id]="inputId"
 		autocomplete="off"
 		[ngClass]="cssClass"

--- a/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.ts
+++ b/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.ts
@@ -23,6 +23,7 @@ import { ChangeData } from './interfaces/change-data';
 import { Country } from './model/country.model';
 import { phoneNumberValidator } from './ngx-intl-tel-input.validator';
 import { PhoneNumberFormat } from './enums/phone-number-format.enum';
+import { BsDropdownDirective } from 'ngx-bootstrap/dropdown';
 
 @Component({
 	// tslint:disable-next-line: component-selector
@@ -78,6 +79,7 @@ export class NgxIntlTelInputComponent implements OnInit, OnChanges {
 	};
 
 	phoneNumber: string | undefined = '';
+	countriesList: Array<Country> = [];
 	allCountries: Array<Country> = [];
 	preferredCountriesInDropDown: Array<Country> = [];
 	// Has to be 'any' to prevent a need to install @types/google-libphonenumber by the package user...
@@ -85,7 +87,10 @@ export class NgxIntlTelInputComponent implements OnInit, OnChanges {
 	disabled = false;
 	errors: Array<any> = ['Phone number is required.'];
 	countrySearchText = '';
+  startTabIndexCounter = 3;
 
+	@ViewChild('dropdownToggle') dropdownToggle: ElementRef;
+	@ViewChild('countryListDropdown') countryListDropdown: BsDropdownDirective;
 	@ViewChild('countryList') countryList: ElementRef;
 
 	onTouched = () => {};
@@ -146,6 +151,20 @@ export class NgxIntlTelInputComponent implements OnInit, OnChanges {
 		this.countryChange.emit(country);
 	}
 
+  public openCountryList(event: Event) {
+    event.preventDefault();
+    this.countrySearchText = '';
+    this.countriesList = [...this.allCountries];
+    this.dropdownToggle.nativeElement.blur();
+
+    if (this.countryListDropdown.isOpen) {
+      this.countryListDropdown.hide();
+    } else {
+      this.countryListDropdown.show();
+      document.getElementById('country-search-box')?.focus();
+    }
+  }
+
 	/**
 	 * Search country based on country name, iso2, dialCode or all of them.
 	 */
@@ -158,12 +177,13 @@ export class NgxIntlTelInputComponent implements OnInit, OnChanges {
 					block: 'nearest',
 					inline: 'nearest',
 				});
+      this.countriesList = [...this.allCountries];
 			return;
 		}
     // Lower case the search text to match the country name and iso2 and ignore `+` from the dial code.
 		const countrySearchTextFormatted = this.countrySearchText.toLowerCase().replace(/[+]/g, '');
     // @ts-ignore
-		const country = this.allCountries.filter((c) => {
+		const countries = this.allCountries.filter((c) => {
 			if (this.searchCountryField.indexOf(SearchCountryField.All) > -1) {
 				// Search in all fields
 				if (c.iso2.toLowerCase().startsWith(countrySearchTextFormatted)) {
@@ -195,18 +215,11 @@ export class NgxIntlTelInputComponent implements OnInit, OnChanges {
 			}
 		});
 
-		if (country.length > 0) {
-			const el = this.countryList.nativeElement.querySelector(
-				'#' + country[0].htmlId
-			);
-			if (el) {
-				el.scrollIntoView({
-					behavior: 'smooth',
-					block: 'nearest',
-					inline: 'nearest',
-				});
-			}
-		}
+		if (countries.length > 0) {
+      this.countriesList = countries;
+		} else {
+      this.countriesList = [...this.allCountries];
+    }
 
 		this.checkSeparateDialCodeStyle();
 	}
@@ -279,6 +292,7 @@ export class NgxIntlTelInputComponent implements OnInit, OnChanges {
 
 	public onCountrySelect(country: Country, el: { focus: () => void; }): void {
 		this.setSelectedCountry(country);
+    this.countryListDropdown.hide();
 
 		this.checkSeparateDialCodeStyle();
 
@@ -507,6 +521,7 @@ export class NgxIntlTelInputComponent implements OnInit, OnChanges {
 
 			this.allCountries.push(country);
 		});
+    this.countriesList = [...this.allCountries];
 	}
 
 	/**

--- a/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.ts
+++ b/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.ts
@@ -160,34 +160,35 @@ export class NgxIntlTelInputComponent implements OnInit, OnChanges {
 				});
 			return;
 		}
-		const countrySearchTextLower = this.countrySearchText.toLowerCase();
+    // Lower case the search text to match the country name and iso2 and ignore `+` from the dial code.
+		const countrySearchTextFormatted = this.countrySearchText.toLowerCase().replace(/[+]/g, '');
     // @ts-ignore
 		const country = this.allCountries.filter((c) => {
 			if (this.searchCountryField.indexOf(SearchCountryField.All) > -1) {
 				// Search in all fields
-				if (c.iso2.toLowerCase().startsWith(countrySearchTextLower)) {
+				if (c.iso2.toLowerCase().startsWith(countrySearchTextFormatted)) {
 					return c;
 				}
-				if (c.name.toLowerCase().startsWith(countrySearchTextLower)) {
+				if (c.name.toLowerCase().startsWith(countrySearchTextFormatted)) {
 					return c;
 				}
-				if (c.dialCode.startsWith(this.countrySearchText)) {
+				if (c.dialCode.startsWith(countrySearchTextFormatted)) {
 					return c;
 				}
 			} else {
 				// Or search by specific SearchCountryField(s)
 				if (this.searchCountryField.indexOf(SearchCountryField.Iso2) > -1) {
-					if (c.iso2.toLowerCase().startsWith(countrySearchTextLower)) {
+					if (c.iso2.toLowerCase().startsWith(countrySearchTextFormatted)) {
 						return c;
 					}
 				}
 				if (this.searchCountryField.indexOf(SearchCountryField.Name) > -1) {
-					if (c.name.toLowerCase().startsWith(countrySearchTextLower)) {
+					if (c.name.toLowerCase().startsWith(countrySearchTextFormatted)) {
 						return c;
 					}
 				}
 				if (this.searchCountryField.indexOf(SearchCountryField.DialCode) > -1) {
-					if (c.dialCode.startsWith(this.countrySearchText)) {
+					if (c.dialCode.startsWith(countrySearchTextFormatted)) {
 						return c;
 					}
 				}


### PR DESCRIPTION
Refers to issue: [Not searching when typing + with the DialCode](https://github.com/webcat12345/ngx-intl-tel-input/issues/461)