### PR TITLE
ngOnChanges deal with onlyCountries updates

### DIFF
--- a/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.ts
+++ b/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.ts
@@ -114,6 +114,9 @@ export class NgxIntlTelInputComponent implements OnInit, OnChanges {
 			this.updatePreferredCountries();
 		}
 		this.checkSeparateDialCodeStyle();
+    if (changes['onlyCountries']) {
+      this.allCountries = this.allCountries.filter((c) => this.onlyCountries.includes(c.iso2));
+    }
 	}
 
 	/*


### PR DESCRIPTION
When updating onlyCountries after been initialized the component (e.g.: loading from backend) the new values of onlyCountries does not get updated in ngx-intl-tel-input. 

Checking in ngOnChanges for changes['onlyCountries'] and updating as necessary solved the issue:

if (changes['onlyCountries']) {
      this.allCountries = this.allCountries.filter((c) => this.onlyCountries.includes(c.iso2));
}