### PR TITLE
  feat: add dropdownMatchInputWidth option

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ Or this:
 | selectedCountryISO       | `<CountryISO>`           | `None`                            | Set specific country on load.                                                                                 |
 | separateDialCode         | `boolean`                | `false`                           | Visually separate dialcode into the drop down element.                                                        |
 | countryChange            | `<Country>`              | `None`                            | Emits country value when the user selects a country from the dropdown.                                        |
+| dropdownMatchInputWidth  | `boolean`                | `false`                           | When enabled, the
+  country dropdown width will match the full width of the input element. |
 
 ## Supported Formats
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "zone.js": "~0.14.3"
       },
       "devDependencies": {
-        "@angular-devkit/build-angular": "^17.3.12",
+        "@angular-devkit/build-angular": "^17.0.0",
         "@angular/cli": "^17.0.0",
         "@angular/compiler-cli": "^17.0.0",
         "@angular/language-service": "^17.0.0",

--- a/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.html
+++ b/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.html
@@ -10,7 +10,7 @@
       <div *ngIf="separateDialCode" class="selected-dial-code">+{{ selectedCountry.dialCode }}</div>
       <div class="iti__arrow"></div>
     </div>
-    <div *dropdownMenu class="dropdown-menu iti__dropdown-content">
+    <div *dropdownMenu class="dropdown-menu iti__dropdown-content" [style.width.px]="dropdownMatchInputWidth ? (telInput.offsetWidth - 0.5) : null">
       <div class="search-container" *ngIf="searchCountryFlag && searchCountryField">
         <input
           id="country-search-box"
@@ -65,5 +65,6 @@
     [attr.maxLength]="maxLength"
     [attr.validation]="phoneValidation"
     #focusable
+    #telInput
   />
 </div>

--- a/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.ts
+++ b/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.ts
@@ -62,6 +62,7 @@ export class NgxIntlTelInputComponent implements OnInit, OnChanges {
   @Input() phoneValidation = true;
   @Input() inputId = 'phone';
   @Input() separateDialCode = false;
+  @Input() dropdownMatchInputWidth = false;
   separateDialCodeClass: string;
 
   @Output() readonly countryChange = new EventEmitter<Country>();
@@ -223,7 +224,7 @@ export class NgxIntlTelInputComponent implements OnInit, OnChanges {
       countryCode =
         number && number.getCountryCode()
           ? // @ts-ignore
-            this.getCountryIsoCode(number.getCountryCode(), number)
+          this.getCountryIsoCode(number.getCountryCode(), number)
           : this.selectedCountry.iso2;
       if (countryCode && countryCode !== this.selectedCountry.iso2) {
         const newCountry = this.allCountries
@@ -370,7 +371,7 @@ export class NgxIntlTelInputComponent implements OnInit, OnChanges {
     let number: lpn.PhoneNumber;
     try {
       number = this.phoneUtil.parse(phoneNumber, countryCode.toUpperCase());
-    } catch (e) {}
+    } catch (e) { }
     // @ts-ignore
     return number;
   }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -26,6 +26,7 @@
         [numberFormat]="PhoneNumberFormat.National"
         name="phone"
         formControlName="phone"
+        [dropdownMatchInputWidth] = "true"
       >
       </ngx-intl-tel-input>
     </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -47,11 +47,6 @@ body {
   outline: none;
 }
 
-@media screen and (max-width: 479px) {
-  .iti .iti__country-list {
-    width: 88.3vw;
-  }
-}
 
 ngx-intl-tel-input input {
   height: 44px;


### PR DESCRIPTION
 Closes [#505](https://github.com/webcat12345/ngx-intl-tel-input/issues/505)

  Problem

  When using ngx-intl-tel-input in certain layouts, the country dropdown renders at a fixed width that doesn't align
   with the input element, resulting in a mismatched UI.

  Solution

  Adds a new boolean input dropdownMatchInputWidth (default: false) that, when enabled, sets the dropdown width to
  match the width of the phone input element.

  <ngx-intl-tel-input
    [dropdownMatchInputWidth]="true"
    ...
  ></ngx-intl-tel-input>

  Changes

  - Added @Input() dropdownMatchInputWidth = false to the component
  - Bound [style.width.px] on the dropdown menu conditionally on the flag
  - Updated README options table with the new input

  Notes

  Defaults to false to preserve existing behaviour for all current users.
