### PR TITLE
Fix for dominican phone numbers

### DIFF
--- a/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.ts
+++ b/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.ts
@@ -431,6 +431,20 @@ export class NgxIntlTelInputComponent implements OnInit, OnChanges {
       });
     });
 
+    // If we haven't matched a secondary country, check whether the typed number is still
+    // a partial prefix of any secondary area code (e.g. '80' is a prefix of DO's '809').
+    // In that case return undefined so the caller keeps the currently selected country
+    // rather than prematurely falling back to the main country (e.g. US).
+    if (matchedCountry === (mainCountry ? mainCountry.iso2 : undefined)) {
+      const isPotentialSecondaryMatch = secondaryCountries.some(
+        // @ts-ignore
+        c => c.areaCodes.some((areaCode: string) => areaCode.startsWith(rawNumber))
+      );
+      if (isPotentialSecondaryMatch) {
+        return undefined;
+      }
+    }
+
     return matchedCountry;
   }
 

--- a/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.ts
+++ b/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.ts
@@ -88,8 +88,8 @@ export class NgxIntlTelInputComponent implements OnInit, OnChanges {
 
   @ViewChild('countryList') countryList: ElementRef;
 
-  onTouched = () => {};
-  propagateChange = (_: ChangeData) => {};
+  onTouched = () => { };
+  propagateChange = (_: ChangeData) => { };
 
   constructor(private countryCodeData: CountryCode) {
     // If this is not set, ngx-bootstrap will try to use the bs3 CSS (which is not what we've embedded) and will
@@ -223,7 +223,7 @@ export class NgxIntlTelInputComponent implements OnInit, OnChanges {
       countryCode =
         number && number.getCountryCode()
           ? // @ts-ignore
-            this.getCountryIsoCode(number.getCountryCode(), number)
+          this.getCountryIsoCode(number.getCountryCode(), number)
           : this.selectedCountry.iso2;
       if (countryCode && countryCode !== this.selectedCountry.iso2) {
         const newCountry = this.allCountries
@@ -370,7 +370,7 @@ export class NgxIntlTelInputComponent implements OnInit, OnChanges {
     let number: lpn.PhoneNumber;
     try {
       number = this.phoneUtil.parse(phoneNumber, countryCode.toUpperCase());
-    } catch (e) {}
+    } catch (e) { }
     // @ts-ignore
     return number;
   }
@@ -431,7 +431,7 @@ export class NgxIntlTelInputComponent implements OnInit, OnChanges {
       });
     });
 
-    // If we haven't matched a secondary country, check whether the typed number is still
+    // If a secondary country was not matched, check whether the typed number is still
     // a partial prefix of any secondary area code (e.g. '80' is a prefix of DO's '809').
     // In that case return undefined so the caller keeps the currently selected country
     // rather than prematurely falling back to the main country (e.g. US).


### PR DESCRIPTION
Closes [https://github.com/webcat12345/ngx-intl-tel-input/issues/588](588)

When a user has Dominican Republic (or any +1 secondary country) selected and types a partial number whose digits are a prefix of a secondary area code (e.g. '80' before completing '809'), getCountryIsoCode was falling back to the US main country and switching the selected flag to US mid-type.
  
The fix checks whether the partial national number could still resolve to a secondary country's area code before defaulting to the main country. If so, it returns undefined, leaving the currently selected country unchanged.