### PR TITLE
Dominica (+1 767) numbers incorrectly identified as US

### DIFF
--- a/projects/ngx-intl-tel-input/src/lib/data/country-code.ts
+++ b/projects/ngx-intl-tel-input/src/lib/data/country-code.ts
@@ -121,7 +121,7 @@ export class CountryCode {
     ['Czech Republic (Česká republika)', CountryISO.CzechRepublic, '420'],
     ['Denmark (Danmark)', CountryISO.Denmark, '45'],
     ['Djibouti', CountryISO.Djibouti, '253'],
-    ['Dominica', CountryISO.Dominica, '1767'],
+    ['Dominica', CountryISO.Dominica, '1', 1, ['767']],
     [
       'Dominican Republic (República Dominicana)',
       CountryISO.DominicanRepublic,

--- a/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.ts
+++ b/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.ts
@@ -431,6 +431,20 @@ export class NgxIntlTelInputComponent implements OnInit, OnChanges {
       });
     });
 
+    // If we haven't matched a secondary country, check whether the typed number is still
+    // a partial prefix of any secondary area code (e.g. '80' is a prefix of DO's '809').
+    // In that case return undefined so the caller keeps the currently selected country
+    // rather than prematurely falling back to the main country (e.g. US).
+    if (matchedCountry === (mainCountry ? mainCountry.iso2 : undefined)) {
+      const isPotentialSecondaryMatch = secondaryCountries.some(
+        // @ts-ignore
+        c => c.areaCodes.some((areaCode: string) => areaCode.startsWith(rawNumber))
+      );
+      if (isPotentialSecondaryMatch) {
+        return undefined;
+      }
+    }
+
     return matchedCountry;
   }
 

--- a/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.ts
+++ b/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.ts
@@ -88,8 +88,8 @@ export class NgxIntlTelInputComponent implements OnInit, OnChanges {
 
   @ViewChild('countryList') countryList: ElementRef;
 
-  onTouched = () => { };
-  propagateChange = (_: ChangeData) => { };
+  onTouched = () => {};
+  propagateChange = (_: ChangeData) => {};
 
   constructor(private countryCodeData: CountryCode) {
     // If this is not set, ngx-bootstrap will try to use the bs3 CSS (which is not what we've embedded) and will
@@ -223,7 +223,7 @@ export class NgxIntlTelInputComponent implements OnInit, OnChanges {
       countryCode =
         number && number.getCountryCode()
           ? // @ts-ignore
-          this.getCountryIsoCode(number.getCountryCode(), number)
+            this.getCountryIsoCode(number.getCountryCode(), number)
           : this.selectedCountry.iso2;
       if (countryCode && countryCode !== this.selectedCountry.iso2) {
         const newCountry = this.allCountries
@@ -370,7 +370,7 @@ export class NgxIntlTelInputComponent implements OnInit, OnChanges {
     let number: lpn.PhoneNumber;
     try {
       number = this.phoneUtil.parse(phoneNumber, countryCode.toUpperCase());
-    } catch (e) { }
+    } catch (e) {}
     // @ts-ignore
     return number;
   }

--- a/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.ts
+++ b/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.ts
@@ -431,20 +431,6 @@ export class NgxIntlTelInputComponent implements OnInit, OnChanges {
       });
     });
 
-    // If a secondary country was not matched, check whether the typed number is still
-    // a partial prefix of any secondary area code (e.g. '80' is a prefix of DO's '809').
-    // In that case return undefined so the caller keeps the currently selected country
-    // rather than prematurely falling back to the main country (e.g. US).
-    if (matchedCountry === (mainCountry ? mainCountry.iso2 : undefined)) {
-      const isPotentialSecondaryMatch = secondaryCountries.some(
-        // @ts-ignore
-        c => c.areaCodes.some((areaCode: string) => areaCode.startsWith(rawNumber))
-      );
-      if (isPotentialSecondaryMatch) {
-        return undefined;
-      }
-    }
-
     return matchedCountry;
   }
 

--- a/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.ts
+++ b/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.ts
@@ -88,8 +88,8 @@ export class NgxIntlTelInputComponent implements OnInit, OnChanges {
 
   @ViewChild('countryList') countryList: ElementRef;
 
-  onTouched = () => {};
-  propagateChange = (_: ChangeData) => {};
+  onTouched = () => { };
+  propagateChange = (_: ChangeData) => { };
 
   constructor(private countryCodeData: CountryCode) {
     // If this is not set, ngx-bootstrap will try to use the bs3 CSS (which is not what we've embedded) and will
@@ -223,7 +223,7 @@ export class NgxIntlTelInputComponent implements OnInit, OnChanges {
       countryCode =
         number && number.getCountryCode()
           ? // @ts-ignore
-            this.getCountryIsoCode(number.getCountryCode(), number)
+          this.getCountryIsoCode(number.getCountryCode(), number)
           : this.selectedCountry.iso2;
       if (countryCode && countryCode !== this.selectedCountry.iso2) {
         const newCountry = this.allCountries
@@ -370,7 +370,7 @@ export class NgxIntlTelInputComponent implements OnInit, OnChanges {
     let number: lpn.PhoneNumber;
     try {
       number = this.phoneUtil.parse(phoneNumber, countryCode.toUpperCase());
-    } catch (e) {}
+    } catch (e) { }
     // @ts-ignore
     return number;
   }
@@ -431,7 +431,7 @@ export class NgxIntlTelInputComponent implements OnInit, OnChanges {
       });
     });
 
-    // If we haven't matched a secondary country, check whether the typed number is still
+    // If a secondary country was not matched, check whether the typed number is still
     // a partial prefix of any secondary area code (e.g. '80' is a prefix of DO's '809').
     // In that case return undefined so the caller keeps the currently selected country
     // rather than prematurely falling back to the main country (e.g. US).


### PR DESCRIPTION
When entering a Dominica phone number (e.g. +17672859610), the component selects the US flag instead of Dominica.
 
Why: All +1 countries share the same country code and are told apart by their area code. Every other +1 country in country-code.ts stores its area code separately (e.g. Jamaica uses ['1', 1, ['876']]), but Dominica had its area code baked into the dial code field as '1767'. So when the library searched for countries with dial code 1, it never found Dominica and fell back to the US.